### PR TITLE
Use NestedGroupOfNamesType

### DIFF
--- a/freeIPA_LDAP_Django.py
+++ b/freeIPA_LDAP_Django.py
@@ -4,7 +4,7 @@
 
 import ldap
 import os
-from django_auth_ldap.config import LDAPSearch, GroupOfNamesType
+from django_auth_ldap.config import LDAPSearch, NestedGroupOfNamesType
 
 LDAP_SERVER = 'ipa.hqvfx.auth'
 AUTH_LDAP_SERVER_URI = 'ldap://' + LDAP_SERVER
@@ -23,7 +23,7 @@ AUTH_LDAP_GROUP_BASE = "cn=groups,cn=accounts,dc=hqvfx,dc=auth"
 AUTH_LDAP_GROUP_FILTER = "(objectClass=groupOfNames)"
 AUTH_LDAP_GROUP_SEARCH = LDAPSearch(AUTH_LDAP_GROUP_BASE,
                                     ldap.SCOPE_SUBTREE, AUTH_LDAP_GROUP_FILTER)
-AUTH_LDAP_GROUP_TYPE = GroupOfNamesType(name_attr="cn")
+AUTH_LDAP_GROUP_TYPE = NestedGroupOfNamesType(name_attr="cn")
 AUTH_LDAP_USER_FLAGS_BY_GROUP = {
     'is_staff': 'cn=ipausers,' + AUTH_LDAP_GROUP_BASE,
     'is_support': 'cn=ipausers,' + AUTH_LDAP_GROUP_BASE,


### PR DESCRIPTION
Recursive group membership doesn't work in the original example.

This change allows a group called "netbox_users" which contains "ipausers" to authenticate successfully.